### PR TITLE
PDT-20331-SDK-Instructional-Funding-Money-Transfer-to-Payee-using-Python-SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,27 +412,6 @@ async def list_charge_splits(params=None):
 asyncio.run(list_charge_splits({'limit': 25, 'page': 2}))
 ```
 
-## Create Split Instructional Funding
-
-### Example: Create Instructional Funding
-
-This example demonstrates how to transfer money to my payees via instructional funding:
-
-```python
-async def create_split_example():
-    split_data = {
-        "mid": "0709900000098856",
-        "amount": 30,
-        "description": "Application fee created"
-    }
-    try:
-        split = await payarc.charges['create_split'](charge_data)
-        print('Success, the money transfer is:', split)
-    except Exception as error:
-        print('Error detected:', error)
-asyncio.run(create_split_example())
-```
-
 ## Listing Charges
 
 ### Example: List Charges with No Constraints

--- a/README.md
+++ b/README.md
@@ -378,6 +378,27 @@ async def list_charge_splits(params=None):
 asyncio.run(list_charge_splits({'limit': 25, 'page': 2}))
 ```
 
+## Create Split Instructional Funding
+
+### Example: Create Instructional Funding
+
+This example demonstrates how to transfer money to my payees via instructional funding:
+
+```python
+async def create_split_example():
+    split_data = {
+        "mid": "0709900000098856",
+        "amount": 30,
+        "description": "Application fee created"
+    }
+    try:
+        split = await payarc.charges['create_split'](charge_data)
+        print('Success, the money transfer is:', split)
+    except Exception as error:
+        print('Error detected:', error)
+asyncio.run(create_split_example())
+```
+
 ## Listing Charges
 
 ### Example: List Charges with No Constraints

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ SDK is build around object payarc. From this object you can access properties an
     create_refund - function to perform a refund over existing charge
     adjust_splits - function to modify splits for existing charge (Only for Merchants configured with instructional funding)
     list_splits - retrieves a list of instructional funding allocations (as ChargeSplit objects) associated with a specific merchant account.
+    create_instructional_funding - function to transfer money to my payees via instructional funding
 ### Object `payarc.user_settings`
 #### Object `payarc.user_settings` is used to manage the webhooks and Callback URLs. This object has following functions: 
     create - this function will create object stored in the database for webhooks in form of key value pair.
@@ -376,6 +377,26 @@ async def adjust_splits_by_charge_obj(id):
     except Exception as error:
         print('Error detected:', error)
 asyncio.run(adjust_splits_by_charge_obj('ch_M*********noOWL'))
+```
+
+### Example: Create Instructional Funding
+This example demonstrates how to transfer money to my payees via instructional funding:
+
+```python
+async def create_instructional_funding():
+    split_data = {
+        "mid": "070990********6",
+        "amount": 30,
+        "description": "Application fee created",
+        # "include": "charge" // optional
+        # "charge_id": "ch_nbDB*******RnMORX" // optional
+    }
+    try:
+        split = await payarc.charges['create_instructional_funding'](split_data)
+        print('Success, the money transfer is:', split)
+    except Exception as error:
+        print('Error detected:', error)
+asyncio.run(create_instructional_funding())
 ```
 ## Listing Splits for Charge with Instructional Funding
 This example demonstrates how to list splits of instructional funding allocations (as ChargeSplit objects) associated with a specific merchant account.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "payarc"
-version = "1.7.6"
+version = "1.7.7"
 dependencies=[
     "httpx",
     "asyncio",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "payarc"
-version = "1.7.8"
+version = "1.7.9"
 dependencies=[
     "httpx",
     "asyncio",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ long_description = (here / "README.md").read_text(encoding="utf-8")
 
 setup(
     name="payarc",
-    version="1.7.8",
+    version="1.7.9",
     description="Payarc Python SDK",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ long_description = (here / "README.md").read_text(encoding="utf-8")
 
 setup(
     name="payarc",
-    version="1.7.6",
+    version="1.7.7",
     description="Payarc Python SDK",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/src/payarc/payarc.py
+++ b/src/payarc/payarc.py
@@ -42,7 +42,8 @@ class Payarc:
             },
             'create_refund': self.__refund_charge,
             'adjust_splits': self.__adjust_charge_splits,
-            'list_splits': self.__list_charge_splits
+            'list_splits': self.__list_charge_splits,
+            'create_split': self.__create_split,
         }
         self.batches = {
             # 'list': self.__list_batches, TODO: implement
@@ -317,6 +318,30 @@ class Payarc:
                                               error.response if error.response else {}))
         except Exception as error:
             raise Exception(self.manage_error({'source': 'API List Charge Splits'}, str(error)))
+        
+    async def __create_split(self, split_data=None):
+        if split_data is None:
+            split_data = {}
+        mid = split_data.get("mid")
+        amount = split_data.get("amount")
+        description = split_data.get("description")
+        include = split_data.get("include", "charge")
+
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(
+                    f"{self.base_url}instructional_funding",
+                    json={"mid": mid, "amount": amount, "description": description},
+                    headers=self.request_headers(self.bearer_token),
+                    params={"include": include}
+                )
+                response.raise_for_status()
+                return self.add_object_id(response.json().get('data'))
+        except httpx.HTTPError as error:
+            raise Exception(self.manage_error({'source': 'API Create Split'},
+                                              error.response if error.response else {}))
+        except Exception as error:
+            raise Exception(self.manage_error({'source': 'API Create Split'}, str(error)))
 
     async def __refund_ach_charge(self, charge, params=None):
         if params is None:

--- a/src/payarc/payarc.py
+++ b/src/payarc/payarc.py
@@ -43,7 +43,7 @@ class Payarc:
             'create_refund': self.__refund_charge,
             'adjust_splits': self.__adjust_charge_splits,
             'list_splits': self.__list_charge_splits,
-            'create_split': self.__create_split,
+            'create_instructional_funding': self.__create_split,
         }
         self.payees = {
             'create': self.__create_payee,
@@ -343,12 +343,15 @@ class Payarc:
         amount = split_data.get("amount")
         description = split_data.get("description")
         include = split_data.get("include", "charge")
-
+        charge_id = split_data.get("charge_id", "")
+        if charge_id.startswith('ch_'):
+            charge_id = charge_id[3:]
+        data = {"charge_id": charge_id, "mid": mid, "amount": amount, "description": description}
         try:
             async with httpx.AsyncClient() as client:
                 response = await client.post(
                     f"{self.base_url}instructional_funding",
-                    json={"mid": mid, "amount": amount, "description": description},
+                    json=data,
                     headers=self.request_headers(self.bearer_token),
                     params={"include": include}
                 )

--- a/tests/main.py
+++ b/tests/main.py
@@ -142,15 +142,18 @@ async def list_charge_splits(params=None):
 
 async def create_charge_split():
     split_data = {
-        "mid": "0709900000098856",
-        "amount": 30,
-        "description": "Application fee created"
+        "mid": "0709900000109900",
+        "amount": 120,
+        "description": "Application fee created",
+        # "include": "charge",
+        # "charge_id": "ch_WBMROoBWnnnDbOyn"
     }
     try:
-        split = await payarc.charges['create_split'](split_data)
+        split = await payarc.charges['create_instructional_funding'](split_data)
         print('Success, the new split is:', split)
     except Exception as error:
         print('Error detected:', error)
+
 
 async def adjust_splits_by_charge_obj():
     try:
@@ -906,70 +909,70 @@ if __name__ == "__main__":
     # asyncio.run(update_webhook_example_by_obj())
     # asyncio.run(list_webhooks_example())
     # asyncio.run(delete_webhook_example())
-     asyncio.run(create_charge_split())
-    # asyncio.run(list_charges({'limit': 50, 'page': 1}))
-    # asyncio.run(list_agent_charges({'from_date': '2025-05-27', 'to_date': '2025-05-28'}))
-    # asyncio.run(get_charge_by_id('ch_WBMROoBWnnnDbOyn'))
-    # asyncio.run(refund_charge('ach_g9dDE7GDdeDG08eA'))
-    # asyncio.run(refund_ach_charge_by_obj('ach_g9dDE7GDdeDG08eA', {}))
-    # asyncio.run(refund_charge_by_obj('ch_MnBROWLXBBXnoOWL',
-    #                                  {'reason': 'requested_by_customer',
-    #                                   'description': 'The customer returned the product, did not like it'}))
-    # asyncio.run(create_customer_example())
-    # asyncio.run(get_customer_by_id('cus_jMNKVMPKnNxPVnDp'))
-    # asyncio.run(update_customer('cus_DPNMVjx4AMNNVnjA'))
-    # asyncio.run(update_customer_by_obj('cus_DPNMVjx4AMNNVnjA'))
-    # asyncio.run(list_customer_with_limit(3))
-    # asyncio.run(delete_customer_by_id('cus_xPpAV4DNjnpKVNjK'))
-    # asyncio.run(add_card_to_customer())
-    # asyncio.run(add_bank_account_to_customer())
-    # asyncio.run(create_charge_by_card_id())
-    # asyncio.run(create_charge_by_token())
-    # asyncio.run(create_charge_by_customer_id())
-    # asyncio.run(create_charge_by_bank_account())
-    # asyncio.run(create_ach_charge_by_bank_account_details())
-    # asyncio.run(add_payee())
-    # asyncio.run(list_payees())
-    asyncio.run(delete_payee_by_id('appl_dpokzgdmz5g50ml8'))
-    # asyncio.run(create_candidate_merchant())
-    # asyncio.run(list_applications())
-    # asyncio.run(get_candiate_merchant_by_id('appl_9d6woe30xye3jz0q'))
-    asyncio.run(get_candiate_merchant_by_id('appl_xmylbgq5r9gv98ra'))
-    asyncio.run(get_lead_status('appl_xmylbgq5r9gv98ra'))
-    # asyncio.run(create_candidate_in_behalf_of_other_agent())
-    # asyncio.run(list_inc_documents())
-    # asyncio.run(update_candidate_merchant('appl_3alndgy6xoep49y8'))
-    # asyncio.run(add_document_to_candidate_merchant('appl_3alndgy6xoep49y8'))
-    # asyncio.run(remove_document_from_candidate_merchant())
-    # asyncio.run(remove_document_by_id())
-    # asyncio.run(create_plan())
-    # asyncio.run(update_plan())
-    # asyncio.run(delete_plan("plan_0d640ccc"))
-    # asyncio.run(create_subscription())
-    # asyncio.run(list_subscription())
-    # asyncio.run(update_subscription())
-    # asyncio.run(list_campaign())
-    # asyncio.run(list_all_processing_merchants())
-    # asyncio.run(create_campaign())
-    # asyncio.run(get_campaign_by_id('cmp_o3**********86n5'))
-    # asyncio.run(update_campaign())
-    # asyncio.run(list_cases())
-    # asyncio.run(list_agent_deposits({
-    #     'from_date': '2024-11-01',
-    #     'to_date': '2024-11-04'
-    # }))
-    # asyncio.run(list_agent_batches({
-    #     'from_date': '2025-05-30',
-    #     'to_date': '2025-05-30'
-    # }))
-    # asyncio.run(get_batch_details({
-    #     # 'batch_reference_number': 'bat_90042693274',
-    #     'mid': '0671900000038430',
-    #     'batch_date': '2025-05-30'
-    # }))
-    # asyncio.run(get_batch_details_by_obj({
-    #     'from_date': '2025-05-30',
-    #     'to_date': '2025-05-30'
-    # }))
-    # asyncio.run(get_case('dis_MVB1AV901Rb1VAW0'))
-    # asyncio.run(submit_case())
+    asyncio.run(create_charge_split())
+# asyncio.run(list_charges({'limit': 50, 'page': 1}))
+# asyncio.run(list_agent_charges({'from_date': '2025-05-27', 'to_date': '2025-05-28'}))
+# asyncio.run(get_charge_by_id('ch_WBMROoBWnnnDbOyn'))
+# asyncio.run(refund_charge('ach_g9dDE7GDdeDG08eA'))
+# asyncio.run(refund_ach_charge_by_obj('ach_g9dDE7GDdeDG08eA', {}))
+# asyncio.run(refund_charge_by_obj('ch_MnBROWLXBBXnoOWL',
+#                                  {'reason': 'requested_by_customer',
+#                                   'description': 'The customer returned the product, did not like it'}))
+# asyncio.run(create_customer_example())
+# asyncio.run(get_customer_by_id('cus_jMNKVMPKnNxPVnDp'))
+# asyncio.run(update_customer('cus_DPNMVjx4AMNNVnjA'))
+# asyncio.run(update_customer_by_obj('cus_DPNMVjx4AMNNVnjA'))
+# asyncio.run(list_customer_with_limit(3))
+# asyncio.run(delete_customer_by_id('cus_xPpAV4DNjnpKVNjK'))
+# asyncio.run(add_card_to_customer())
+# asyncio.run(add_bank_account_to_customer())
+# asyncio.run(create_charge_by_card_id())
+# asyncio.run(create_charge_by_token())
+# asyncio.run(create_charge_by_customer_id())
+# asyncio.run(create_charge_by_bank_account())
+# asyncio.run(create_ach_charge_by_bank_account_details())
+# asyncio.run(add_payee())
+# asyncio.run(list_payees())
+# asyncio.run(delete_payee_by_id('appl_dpokzgdmz5g50ml8'))
+# asyncio.run(create_candidate_merchant())
+# asyncio.run(list_applications())
+# asyncio.run(get_candiate_merchant_by_id('appl_9d6woe30xye3jz0q'))
+# asyncio.run(get_candiate_merchant_by_id('appl_xmylbgq5r9gv98ra'))
+# asyncio.run(get_lead_status('appl_xmylbgq5r9gv98ra'))
+# asyncio.run(create_candidate_in_behalf_of_other_agent())
+# asyncio.run(list_inc_documents())
+# asyncio.run(update_candidate_merchant('appl_3alndgy6xoep49y8'))
+# asyncio.run(add_document_to_candidate_merchant('appl_3alndgy6xoep49y8'))
+# asyncio.run(remove_document_from_candidate_merchant())
+# asyncio.run(remove_document_by_id())
+# asyncio.run(create_plan())
+# asyncio.run(update_plan())
+# asyncio.run(delete_plan("plan_0d640ccc"))
+# asyncio.run(create_subscription())
+# asyncio.run(list_subscription())
+# asyncio.run(update_subscription())
+# asyncio.run(list_campaign())
+# asyncio.run(list_all_processing_merchants())
+# asyncio.run(create_campaign())
+# asyncio.run(get_campaign_by_id('cmp_o3**********86n5'))
+# asyncio.run(update_campaign())
+# asyncio.run(list_cases())
+# asyncio.run(list_agent_deposits({
+#     'from_date': '2024-11-01',
+#     'to_date': '2024-11-04'
+# }))
+# asyncio.run(list_agent_batches({
+#     'from_date': '2025-05-30',
+#     'to_date': '2025-05-30'
+# }))
+# asyncio.run(get_batch_details({
+#     # 'batch_reference_number': 'bat_90042693274',
+#     'mid': '0671900000038430',
+#     'batch_date': '2025-05-30'
+# }))
+# asyncio.run(get_batch_details_by_obj({
+#     'from_date': '2025-05-30',
+#     'to_date': '2025-05-30'
+# }))
+# asyncio.run(get_case('dis_MVB1AV901Rb1VAW0'))
+# asyncio.run(submit_case())

--- a/tests/main.py
+++ b/tests/main.py
@@ -140,6 +140,18 @@ async def list_charge_splits(params=None):
         print('Error detected:', error)
 
 
+async def create_charge_split():
+    split_data = {
+        "mid": "0709900000098856",
+        "amount": 30,
+        "description": "Application fee created"
+    }
+    try:
+        split = await payarc.charges['create_split'](split_data)
+        print('Success, the new split is:', split)
+    except Exception as error:
+        print('Error detected:', error)
+
 async def adjust_splits_by_charge_obj():
     try:
         charge = await payarc.charges['retrieve']('ch_WBMROoBWnnnDbOyn')
@@ -770,7 +782,8 @@ if __name__ == "__main__":
     # asyncio.run(create_instructional_funding_charge())
     # asyncio.run(adjust_splits_by_charge_id('ch_WBMROoBWnnnDbOyn'))
     # asyncio.run(adjust_splits_by_charge_obj())
-    asyncio.run(list_charge_splits({'limit': 25, 'page': 2}))
+    # asyncio.run(list_charge_splits({'limit': 25, 'page': 2}))
+    asyncio.run(create_charge_split())
     # asyncio.run(list_charges({'limit': 50, 'page': 1}))
     # asyncio.run(list_agent_charges({'from_date': '2025-05-27', 'to_date': '2025-05-28'}))
     # asyncio.run(get_charge_by_id('ch_WBMROoBWnnnDbOyn'))


### PR DESCRIPTION
- Implemented `__create_split` method in Payarc class for creating instructional funding splits.
- Updated README.md with an example for creating instructional funding.
- Added a test case for creating charge splits in main.py.
- Bumped version to 1.7.7 in setup.py and pyproject.toml.